### PR TITLE
Add max_redemptions to promo code create

### DIFF
--- a/generate_coupons.py
+++ b/generate_coupons.py
@@ -16,7 +16,10 @@ coupon = stripe.Coupon.create(
 promotion_codes = []
 
 for _ in range(1000):
-    promotion_code = stripe.PromotionCode.create(coupon=coupon.id)
+    promotion_code = stripe.PromotionCode.create(
+        coupon=coupon.id,
+        max_redemptions=1, # This ensures each promo code can only be used once
+    )
     promotion_codes.append([promotion_code.code])
     print(f"Generated promotion code {promotion_code.code}")
 


### PR DESCRIPTION
Adds a default `max_redemptions=1` to allow each promo code to be used just a single time.  (I believe it [otherwise defaults to `null`](https://docs.stripe.com/api/promotion_codes/object#promotion_code_object-max_redemptions))